### PR TITLE
refactor: update version checks to game.release.version

### DIFF
--- a/module/scripts/chat-roll-privacy.js
+++ b/module/scripts/chat-roll-privacy.js
@@ -89,7 +89,7 @@ export default class ChatRollPrivacy {
     for (const [k, v] of Object.entries(data.rollModes)) {
       let rt, name;
 
-      if (foundry.utils.isNewerVersion(game.version, 12)) {
+      if (foundry.utils.isNewerVersion(game.release.version, "12")) {
         rt = v.value;
         name = v.label;
       } else {

--- a/module/scripts/pause-icon-script.js
+++ b/module/scripts/pause-icon-script.js
@@ -21,7 +21,7 @@ Hooks.on("renderPause", function (_,html, options) {
     }
     else {
         html.find("img").attr("src", path);
-        if(foundry.utils.isNewerVersion(game.version, "10")){
+        if(foundry.utils.isNewerVersion(game.release.version, "10")){
 			html.find("img").addClass("fa-spin")
             html.find("img").css({"top": top, "left": left, "width": dimensionX, "height": dimensionY, "opacity": opacity, "--fa-animation-duration": speed});
         }
@@ -30,7 +30,7 @@ Hooks.on("renderPause", function (_,html, options) {
             html.find("img").css({"top": top, "left": left, "width": dimensionX, "height": dimensionY, "opacity": opacity, "-webkit-animation": speed});
         }
     }
-    if(foundry.utils.isNewerVersion(game.version, "10")){
+    if(foundry.utils.isNewerVersion(game.release.version, "10")){
         html.find("figcaption").text(text);
         if (text.length !== 0 && shadow) {
             html.css({"background-size": size});


### PR DESCRIPTION
## Summary
- replace deprecated `game.version` references with `game.release.version`
- keep version comparisons up to date in chat-roll-privacy and pause-icon-script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a82eec7260832790d5e430ec668265