### PR TITLE
refactor settings access to storage api

### DIFF
--- a/module/scripts/rpg-ui.js
+++ b/module/scripts/rpg-ui.js
@@ -4,7 +4,7 @@ import AllianceViewer from './alliance-viewer.js';
 Hooks.on('ready', async () => {
     // Retrait de la classe de Monk's Little Details
     // Créer une erreur lorsque le module n'est pas activé
-        if (game.settings.settings.has('monks-little-details.window-css-changes')) {
+        if (game.settings.storage.get("client").has("monks-little-details.window-css-changes")) {
                 game.settings.set("monks-little-details", "window-css-changes", false);
                 $("body").removeClass("change-windows");
         }


### PR DESCRIPTION
## Summary
- use Foundry's settings storage API instead of direct settings map access

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a82eed9e548327b1b88940f7c021b6