### PR TITLE
Use root element for chat log click handler

### DIFF
--- a/module/scripts/rpg-ui.js
+++ b/module/scripts/rpg-ui.js
@@ -348,11 +348,15 @@ Hooks.on('renderChatMessage', (chat, html) => {
 });
 
 Hooks.on('renderChatLogPF2e', (chat, html) => {
+  const root = html?.[0];
+  if (!root) {
+    return;
+  }
   if (!game.settings.get('pathfinder-ui', 'openSheetOnChatClick')) {
     return;
   }
 
-  html[0].addEventListener('click', async (event) => {
+  root.addEventListener('click', async (event) => {
     const target = event.target;
     if (!target || (
       !target.classList.contains('message-sender') // Actor name


### PR DESCRIPTION
## Summary
- Guard chat log click listener by ensuring a DOM root exists
- Attach click handler to the root element rather than html[0]

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a83757f0348327af3fbdd72d18f633