### PR TITLE
refactor: remove jquery usage

### DIFF
--- a/module/scripts/alliance-viewer.js
+++ b/module/scripts/alliance-viewer.js
@@ -27,22 +27,24 @@ export default class AllianceViewer {
       return;
     }
 
-    const documentList = html.find('li.directory-item.document');
+    const documentList = html[0].querySelectorAll('li.directory-item.document');
     const collection = object.constructor.collection;
 
     // Interate through each directory list item.
-    for (let li of documentList) {
-      li = $(li);
-      const document = collection.get(li.attr('data-document-id'));
+    for (const li of documentList) {
+      const actorDoc = collection.get(li.dataset.documentId);
 
-      if (!['character', 'npc'].includes(document.type)) {
+      if (!['character', 'npc'].includes(actorDoc.type)) {
         continue;
       }
 
-      const alliance = AllianceViewer.#getDocumentAlliance(document);
+      const alliance = AllianceViewer.#getDocumentAlliance(actorDoc);
 
-      li.append($(`<div class="pfui-alliance-viewer alliance-${alliance}" data-actor-id="${document.id}" 
-data-tooltip="${AllianceViewer.#getTooltip(alliance)}"></div>`));
+      const marker = document.createElement('div');
+      marker.classList.add('pfui-alliance-viewer', `alliance-${alliance}`);
+      marker.dataset.actorId = actorDoc.id;
+      marker.dataset.tooltip = AllianceViewer.#getTooltip(alliance);
+      li.appendChild(marker);
     }
   }
 

--- a/module/scripts/chat-roll-privacy.js
+++ b/module/scripts/chat-roll-privacy.js
@@ -16,7 +16,7 @@ export default class ChatRollPrivacy {
       editable: [{ key: 'KeyQ', modifiers: [KeyboardManager.MODIFIER_KEYS.ALT] }],
       namespace: 'Roll Type Shortcuts',
       onDown: () => {
-        $('#rpg-ui-buttons > button[data-id="publicroll"]').trigger('click');
+        document.querySelector('#rpg-ui-buttons > button[data-id="publicroll"]')?.click();
       },
     });
     game.keybindings.register('pathfinder-ui', 'roll-mode.gmroll', {
@@ -24,7 +24,7 @@ export default class ChatRollPrivacy {
       editable: [{ key: 'KeyW', modifiers: [KeyboardManager.MODIFIER_KEYS.ALT] }],
       namespace: 'Roll Type Shortcuts',
       onDown: () => {
-        $('#rpg-ui-buttons > button[data-id="gmroll"]').trigger('click');
+        document.querySelector('#rpg-ui-buttons > button[data-id="gmroll"]')?.click();
       },
     });
     game.keybindings.register('pathfinder-ui', 'roll-mode.blindroll', {
@@ -32,7 +32,7 @@ export default class ChatRollPrivacy {
       editable: [{ key: 'KeyE', modifiers: [KeyboardManager.MODIFIER_KEYS.ALT] }],
       namespace: 'Roll Type Shortcuts',
       onDown: () => {
-        $('#rpg-ui-buttons > button[data-id="blindroll"]').trigger('click');
+        document.querySelector('#rpg-ui-buttons > button[data-id="blindroll"]')?.click();
       },
     });
     game.keybindings.register('pathfinder-ui', 'roll-mode.selfroll', {
@@ -40,7 +40,7 @@ export default class ChatRollPrivacy {
       editable: [{ key: 'KeyR', modifiers: [KeyboardManager.MODIFIER_KEYS.ALT] }],
       namespace: 'Roll Type Shortcuts',
       onDown: () => {
-        $('#rpg-ui-buttons > button[data-id="selfroll"]').trigger('click');
+        document.querySelector('#rpg-ui-buttons > button[data-id="selfroll"]')?.click();
       },
     });
   }
@@ -109,41 +109,54 @@ export default class ChatRollPrivacy {
         colour: ChatRollPrivacy.calcColour(iconKeys.findIndex(x => x == rt), iconKeys.length),
       });
     }
-    const buttonHtml = $(await renderTemplate('modules/pathfinder-ui/templates/privacy-button.hbs', { buttons }));
-    buttonHtml.find('button').on('click', function () {
-      const rollType = $(this).attr('data-id');
-      game.settings.set('core', 'rollMode', rollType);
-      buttonHtml.find('button.active').removeClass('active');
-      $(this).addClass('active');
+    const temp = document.createElement('div');
+    temp.innerHTML = await renderTemplate('modules/pathfinder-ui/templates/privacy-button.hbs', { buttons });
+    const buttonHtml = temp.firstElementChild;
+    buttonHtml.querySelectorAll('button').forEach(button => {
+      button.addEventListener('click', () => {
+        const rollType = button.getAttribute('data-id');
+        game.settings.set('core', 'rollMode', rollType);
+        const active = buttonHtml.querySelector('button.active');
+        if (active) active.classList.remove('active');
+        button.classList.add('active');
+      });
     });
-    html.find('select[name=rollMode]').after(buttonHtml);
-    html.find('select[name=rollMode]').remove();
+    const select = html[0].querySelector('select[name=rollMode]');
+    if (select) {
+      select.after(buttonHtml);
+      select.remove();
+    }
 
     if (!game.settings.get('pathfinder-ui', 'replace-buttons'))
       return;
 
     // Adjust the button container to remove the extra margin since those buttons are now moving in.
-    buttonHtml.attr('style', 'margin:0 0 0 0.5em');
+    buttonHtml.style.margin = '0 0 0 0.5em';
 
     // Convert the old <a> tag elements to <button> tags
     let first = true;
-    html.find('#chat-controls div.control-buttons a').each(function () {
-      const html = $(this).html();
-      const classes = $(this).attr('class');
-      const ariaLabel = $(this).attr('aria-label');
-      const tooltip = $(this).attr('data-tooltip');
-      const style = $(this).attr('style');
-      const click = $._data(this, 'events')['click'][0].handler;
-      const button = $(`<button class="${classes}" aria-label="${ariaLabel}" data-tooltip="${tooltip}" style="${style}">${html}</button>`);
-      button.on('click', click);
+    html[0].querySelectorAll('#chat-controls div.control-buttons a').forEach(a => {
+      const htmlContent = a.innerHTML;
+      const classes = a.className;
+      const ariaLabel = a.getAttribute('aria-label');
+      const tooltip = a.getAttribute('data-tooltip');
+      const style = a.getAttribute('style');
+      const button = document.createElement('button');
+      button.className = classes;
+      if (ariaLabel) button.setAttribute('aria-label', ariaLabel);
+      if (tooltip) button.setAttribute('data-tooltip', tooltip);
+      if (style) button.setAttribute('style', style);
+      button.innerHTML = htmlContent;
+      button.addEventListener('click', () => a.click());
       // Add a small margin between the first button and the RollTypes
       if (first) {
-        button.attr('style', 'margin-left:0.5em');
+        button.style.marginLeft = '0.5em';
         first = false;
       }
-      buttonHtml.append(button);
+      buttonHtml.appendChild(button);
     });
 
-    html.find('#chat-controls div.control-buttons').remove();
+    const controls = html[0].querySelector('#chat-controls div.control-buttons');
+    if (controls) controls.remove();
   }
 }

--- a/module/scripts/pause-icon-script.js
+++ b/module/scripts/pause-icon-script.js
@@ -2,8 +2,9 @@ import {registerSettings} from "./pause-icon-settings.js"
 Hooks.on('setup', () => {
     registerSettings();
 });
-Hooks.on("renderPause", function (_,html, options) {
+Hooks.on("renderPause", function (_, html, options) {
     if (!options.paused) return;
+    const root = html[0];
     const path = game.settings.get("pathfinder-ui", "allSettings").path;
     const opacity = game.settings.get("pathfinder-ui", "allSettings").opacity / 100;
     let speed = game.settings.get("pathfinder-ui", "allSettings").speed + "s";
@@ -16,48 +17,70 @@ Hooks.on("renderPause", function (_,html, options) {
     const shadow = game.settings.get("pathfinder-ui", "allSettings").shadow;
     const fontSize = game.settings.get("pathfinder-ui", "allSettings").fontSize;
     const size = `${(text.length * fontSize * 90 / 12) + 70}px 100px`;
-    if(path === "None" || dimensionX === 0 || dimensionY === 0) {
-        html.find("#pause.paused img").hide();
+    if (path === "None" || dimensionX === 0 || dimensionY === 0) {
+        const pauseImg = root.querySelector("#pause.paused img");
+        if (pauseImg) pauseImg.style.display = "none";
     }
     else {
-        html.find("img").attr("src", path);
-        if(foundry.utils.isNewerVersion(game.release.version, "10")){
-			html.find("img").addClass("fa-spin")
-            html.find("img").css({"top": top, "left": left, "width": dimensionX, "height": dimensionY, "opacity": opacity, "--fa-animation-duration": speed});
-        }
-        else{
-            speed += " linear 0s infinite normal none running rotation";
-            html.find("img").css({"top": top, "left": left, "width": dimensionX, "height": dimensionY, "opacity": opacity, "-webkit-animation": speed});
+        const img = root.querySelector("img");
+        if (img) {
+            img.setAttribute("src", path);
+            if (foundry.utils.isNewerVersion(game.release.version, "10")) {
+                img.classList.add("fa-spin");
+                img.style.top = top;
+                img.style.left = left;
+                img.style.width = `${dimensionX}px`;
+                img.style.height = `${dimensionY}px`;
+                img.style.opacity = opacity;
+                img.style.setProperty('--fa-animation-duration', speed);
+            }
+            else {
+                speed += " linear 0s infinite normal none running rotation";
+                img.style.top = top;
+                img.style.left = left;
+                img.style.width = `${dimensionX}px`;
+                img.style.height = `${dimensionY}px`;
+                img.style.opacity = opacity;
+                img.style.setProperty('-webkit-animation', speed);
+            }
         }
     }
-    if(foundry.utils.isNewerVersion(game.release.version, "10")){
-        html.find("figcaption").text(text);
-        if (text.length !== 0 && shadow) {
-            html.css({"background-size": size});
-            html.find("figcaption").css({"color": textColor, "font-size": `${fontSize}em`});
-        }
-        else if(text.length !== 0 && !shadow) {
-            html.find("figcaption").css({"color": textColor, "font-size": `${fontSize}em`});
-            html.find("figcaption").css({"color": textColor});
-            html.css("background", "none");
-        }
-        else {
-            html.css("background", "none");
+    if (foundry.utils.isNewerVersion(game.release.version, "10")) {
+        const caption = root.querySelector("figcaption");
+        if (caption) {
+            caption.textContent = text;
+            if (text.length !== 0 && shadow) {
+                root.style.backgroundSize = size;
+                caption.style.color = textColor;
+                caption.style.fontSize = `${fontSize}em`;
+            }
+            else if (text.length !== 0 && !shadow) {
+                caption.style.color = textColor;
+                caption.style.fontSize = `${fontSize}em`;
+                root.style.background = "none";
+            }
+            else {
+                root.style.background = "none";
+            }
         }
     }
     else {
-        html.find(".paused h3").text(text);
-        if (text.length !== 0 && shadow) {
-            html.css({"background-size": size});
-            html.find("h3").css({"color": textColor, "font-size": `${fontSize}em`});
-        }
-        else if(text.length !== 0 && !shadow) {
-            html.find("h3").css({"color": textColor, "font-size": `${fontSize}em`});
-            html.find("h3").css({"color": textColor});
-            html.css("background", "none");
-        }
-        else {
-            html.css("background", "none");
+        const header = root.querySelector(".paused h3");
+        if (header) {
+            header.textContent = text;
+            if (text.length !== 0 && shadow) {
+                root.style.backgroundSize = size;
+                header.style.color = textColor;
+                header.style.fontSize = `${fontSize}em`;
+            }
+            else if (text.length !== 0 && !shadow) {
+                header.style.color = textColor;
+                header.style.fontSize = `${fontSize}em`;
+                root.style.background = "none";
+            }
+            else {
+                root.style.background = "none";
+            }
         }
     }
 });

--- a/module/scripts/rpg-ui.js
+++ b/module/scripts/rpg-ui.js
@@ -6,7 +6,7 @@ Hooks.on('ready', async () => {
     // Créer une erreur lorsque le module n'est pas activé
         if (game.settings.storage.get("client").has("monks-little-details.window-css-changes")) {
                 game.settings.set("monks-little-details", "window-css-changes", false);
-                $("body").removeClass("change-windows");
+                document.body.classList.remove("change-windows");
         }
 		if (game.modules.has('pf2e-dorako-ui') && game.modules.get('pf2e-dorako-ui').active) {
 			ui.notifications.error(game.i18n.localize('RPGUI.SETTINGS.DORAKOUI'));
@@ -316,10 +316,12 @@ function rpgUIAddCursor() {
 
 Hooks.on('renderSidebarTab', async (object, html) => {
 	if (object instanceof Settings) {
-	  const details = html.find('#game-details')
-	  const list = document.createElement('ul')
-	  list.innerHTML = await renderTemplate('modules/pathfinder-ui/templates/settings-info.hbs')
-	  details.append(list.firstChild)
+          const details = html[0].querySelector('#game-details')
+          if (details) {
+            const list = document.createElement('ul')
+            list.innerHTML = await renderTemplate('modules/pathfinder-ui/templates/settings-info.hbs')
+            details.append(list.firstChild)
+          }
 	}
   })
 


### PR DESCRIPTION
## Summary
- replace jQuery DOM queries and event handlers with native APIs
- simplify roll type buttons and keybindings to click elements directly
- drop jQuery dependencies in pause rendering and actor directory hooks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a839a7a2e883279d19f8d2fd713ff5