### PR TITLE
Refactor dark sheet hooks for Foundry v13

### DIFF
--- a/module/scripts/dark-custom.js
+++ b/module/scripts/dark-custom.js
@@ -19,12 +19,11 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderJournalSheetPF2e", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkJournalToggle') !== "standard" ) {
-        for (const element of document.querySelectorAll(".journal-entry")) {
-            let mode = game.settings.get('pathfinder-ui', 'darkJournalToggle');
-            element.classList.add("dark-custom");
-            element.classList.add(mode);
-        }
+Hooks.on("renderJournalSheetPF2e", (app, html) => {
+    if (game.settings.get('pathfinder-ui', 'darkJournalToggle') !== 'standard') {
+        let mode = game.settings.get('pathfinder-ui', 'darkJournalToggle');
+        app.element.classList.add('dark-custom');
+        app.element.classList.add(mode);
     }
 })
+

--- a/module/scripts/dark-hazard-sheet.js
+++ b/module/scripts/dark-hazard-sheet.js
@@ -19,12 +19,11 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderHazardSheetPF2e", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkHazardSheetToggle') !== "standard" ) {
-        for (const element of document.querySelectorAll(".sheet.hazard")) {
-            let mode = game.settings.get('pathfinder-ui', 'darkHazardSheetToggle');
-            element.classList.add("dark-hazard-theme");
-            element.classList.add(mode);
-        }
+Hooks.on("renderHazardSheetPF2e", (app, html) => {
+    if (game.settings.get('pathfinder-ui', 'darkHazardSheetToggle') !== 'standard') {
+        let mode = game.settings.get('pathfinder-ui', 'darkHazardSheetToggle');
+        app.element.classList.add('dark-hazard-theme');
+        app.element.classList.add(mode);
     }
 })
+

--- a/module/scripts/dark-kingdom-sheet.js
+++ b/module/scripts/dark-kingdom-sheet.js
@@ -18,12 +18,22 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderActorSheet", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkSheetKingdomToggle') !== "standard" ) {
-        for (const element of document.querySelectorAll(".sheet.kingdom, .sheet.kingdom-builder")) {
-            let mode = game.settings.get('pathfinder-ui', 'darkSheetKingdomToggle');
-            element.classList.add("dark-kingdom-theme");
-            element.classList.add(mode);
-        }
+Hooks.on("renderActorSheet", (app, html) => {
+    if (
+        game.settings.get('pathfinder-ui', 'darkSheetKingdomToggle') !== 'standard' &&
+        app.element.classList.contains('kingdom')
+    ) {
+        let mode = game.settings.get('pathfinder-ui', 'darkSheetKingdomToggle');
+        app.element.classList.add('dark-kingdom-theme');
+        app.element.classList.add(mode);
     }
 })
+
+Hooks.on("renderKingdomBuilder", (app, html) => {
+    if (game.settings.get('pathfinder-ui', 'darkSheetKingdomToggle') !== 'standard') {
+        let mode = game.settings.get('pathfinder-ui', 'darkSheetKingdomToggle');
+        app.element.classList.add('dark-kingdom-theme');
+        app.element.classList.add(mode);
+    }
+})
+

--- a/module/scripts/dark-loot-sheet.js
+++ b/module/scripts/dark-loot-sheet.js
@@ -19,12 +19,11 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderLootSheetPF2e", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkLootSheetToggle') !== "standard" ) {
-        for (const element of document.querySelectorAll(".sheet.actor.loot")) {
-            let mode = game.settings.get('pathfinder-ui', 'darkLootSheetToggle');
-            element.classList.add("dark-loot-theme");
-            element.classList.add(mode);
-        }
+Hooks.on("renderLootSheetPF2e", (app, html) => {
+    if (game.settings.get('pathfinder-ui', 'darkLootSheetToggle') !== 'standard') {
+        let mode = game.settings.get('pathfinder-ui', 'darkLootSheetToggle');
+        app.element.classList.add('dark-loot-theme');
+        app.element.classList.add(mode);
     }
 })
+

--- a/module/scripts/dark-npc-sheet.js
+++ b/module/scripts/dark-npc-sheet.js
@@ -19,12 +19,11 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderNPCSheetPF2e", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkNpcSheetToggle') !== "standard" ) {
-        for (const element of document.querySelectorAll(".actor.npc")) {
-            let mode = game.settings.get('pathfinder-ui', 'darkNpcSheetToggle');
-            element.classList.add("dark-npc-theme");
-            element.classList.add(mode);
-        }
+Hooks.on("renderNPCSheetPF2e", (app, html) => {
+    if (game.settings.get('pathfinder-ui', 'darkNpcSheetToggle') !== 'standard') {
+        let mode = game.settings.get('pathfinder-ui', 'darkNpcSheetToggle');
+        app.element.classList.add('dark-npc-theme');
+        app.element.classList.add(mode);
     }
 })
+

--- a/module/scripts/dark-party-sheet.js
+++ b/module/scripts/dark-party-sheet.js
@@ -18,12 +18,14 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderActorSheet", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkPartySheetToggle') !== "standard" ) {
-        for (const element of document.querySelectorAll(".sheet.party")) {
-            let mode = game.settings.get('pathfinder-ui', 'darkPartySheetToggle');
-            element.classList.add("dark-party-theme");
-            element.classList.add(mode);
-        }
+Hooks.on("renderActorSheet", (app, html) => {
+    if (
+        game.settings.get('pathfinder-ui', 'darkPartySheetToggle') !== "standard" &&
+        app.element.classList.contains('party')
+    ) {
+        let mode = game.settings.get('pathfinder-ui', 'darkPartySheetToggle');
+        app.element.classList.add('dark-party-theme');
+        app.element.classList.add(mode);
     }
 })
+

--- a/module/scripts/dark-sheet.js
+++ b/module/scripts/dark-sheet.js
@@ -20,12 +20,14 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderActorSheet", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkSheetToggle') !== "standard" ) {
-        for (const element of document.querySelectorAll(".sheet.character")) {
-            let mode = game.settings.get('pathfinder-ui', 'darkSheetToggle');
-            element.classList.add("dark-theme");
-            element.classList.add(mode);
-        }
+Hooks.on("renderActorSheet", (app, html) => {
+    if (
+        game.settings.get('pathfinder-ui', 'darkSheetToggle') !== 'standard' &&
+        app.element.classList.contains('character')
+    ) {
+        let mode = game.settings.get('pathfinder-ui', 'darkSheetToggle');
+        app.element.classList.add('dark-theme');
+        app.element.classList.add(mode);
     }
 })
+


### PR DESCRIPTION
## Summary
- update dark sheet render hooks to use `(app, html)` callback
- scope styling to sheet root elements for party, character, hazard, loot, NPC, journal, and kingdom sheets
- support kingdom builder with dedicated hook

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a839a61768832794c861346ab482fe