### PR TITLE
fix: prevent duplicate loot and hazard sheet hooks

### DIFF
--- a/module/scripts/dark-hazard-sheet.js
+++ b/module/scripts/dark-hazard-sheet.js
@@ -19,25 +19,10 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderHazardSheetPF2e", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkHazardSheetToggle') !== "standard" ) {
-        const elements = document.querySelectorAll(".sheet.hazard");
-        if (!elements.length) {
-            console.error('No elements found for selector .sheet.hazard');
-            return;
-        }
-        const mode = game.settings.get('pathfinder-ui', 'darkHazardSheetToggle');
-        for (const element of elements) {
-            element.classList.add("dark-hazard-theme");
-            element.classList.add(mode);
-        }
-    }
-})
-Hooks.on("renderHazardSheetPF2e", (app, html) => {
+Hooks.on("renderHazardSheetPF2e", (app) => {
     if (game.settings.get('pathfinder-ui', 'darkHazardSheetToggle') !== 'standard') {
-        let mode = game.settings.get('pathfinder-ui', 'darkHazardSheetToggle');
-        app.element.classList.add('dark-hazard-theme');
-        app.element.classList.add(mode);
+        const mode = game.settings.get('pathfinder-ui', 'darkHazardSheetToggle');
+        app.element.classList.add('dark-hazard-theme', mode);
     }
 })
 

--- a/module/scripts/dark-loot-sheet.js
+++ b/module/scripts/dark-loot-sheet.js
@@ -19,25 +19,10 @@ Hooks.on("init", () => {
     });
 })
 
-Hooks.on("renderLootSheetPF2e", () => {
-    if ( game.settings.get('pathfinder-ui', 'darkLootSheetToggle') !== "standard" ) {
-        const elements = document.querySelectorAll(".sheet.actor.loot");
-        if (!elements.length) {
-            console.error('No elements found for selector .sheet.actor.loot');
-            return;
-        }
-        const mode = game.settings.get('pathfinder-ui', 'darkLootSheetToggle');
-        for (const element of elements) {
-            element.classList.add("dark-loot-theme");
-            element.classList.add(mode);
-        }
-    }
-})
-Hooks.on("renderLootSheetPF2e", (app, html) => {
+Hooks.on("renderLootSheetPF2e", (app) => {
     if (game.settings.get('pathfinder-ui', 'darkLootSheetToggle') !== 'standard') {
-        let mode = game.settings.get('pathfinder-ui', 'darkLootSheetToggle');
-        app.element.classList.add('dark-loot-theme');
-        app.element.classList.add(mode);
+        const mode = game.settings.get('pathfinder-ui', 'darkLootSheetToggle');
+        app.element.classList.add('dark-loot-theme', mode);
     }
 })
 


### PR DESCRIPTION
## Summary
- remove redundant loot and hazard sheet render hooks
- consolidate classList additions to ensure single pass per render

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check module/scripts/dark-loot-sheet.js`
- `node --check module/scripts/dark-hazard-sheet.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8590fbbac8327b646dd79967c601c