### PR TITLE
Fix typo in German language label

### DIFF
--- a/module/module.json
+++ b/module/module.json
@@ -76,7 +76,7 @@
     },
     {
       "lang": "de",
-      "name": "German (Deutch)",
+      "name": "German (Deutsch)",
       "path": "lang/de.json",
       "flags": {}
     }


### PR DESCRIPTION
## Summary
- correct the German language entry from "German (Deutch)" to "German (Deutsch)"

## Testing
- `jq empty module/module.json`


------
https://chatgpt.com/codex/tasks/task_e_68a8590f0e8883278774af9eb2d4fb7e