### PR TITLE
Separate Hook handlers in dark theme scripts

### DIFF
--- a/module/scripts/dark-custom.js
+++ b/module/scripts/dark-custom.js
@@ -31,6 +31,9 @@ Hooks.on("renderJournalSheetPF2e", () => {
             element.classList.add("dark-custom");
             element.classList.add(mode);
         }
+    }
+})
+
 Hooks.on("renderJournalSheetPF2e", (app, html) => {
     if (game.settings.get('pathfinder-ui', 'darkJournalToggle') !== 'standard') {
         let mode = game.settings.get('pathfinder-ui', 'darkJournalToggle');

--- a/module/scripts/dark-npc-sheet.js
+++ b/module/scripts/dark-npc-sheet.js
@@ -31,6 +31,9 @@ Hooks.on("renderNPCSheetPF2e", () => {
             element.classList.add("dark-npc-theme");
             element.classList.add(mode);
         }
+    }
+})
+
 Hooks.on("renderNPCSheetPF2e", (app, html) => {
     if (game.settings.get('pathfinder-ui', 'darkNpcSheetToggle') !== 'standard') {
         let mode = game.settings.get('pathfinder-ui', 'darkNpcSheetToggle');

--- a/module/scripts/dark-party-sheet.js
+++ b/module/scripts/dark-party-sheet.js
@@ -30,6 +30,9 @@ Hooks.on("renderActorSheet", () => {
             element.classList.add("dark-party-theme");
             element.classList.add(mode);
         }
+    }
+})
+
 Hooks.on("renderActorSheet", (app, html) => {
     if (
         game.settings.get('pathfinder-ui', 'darkPartySheetToggle') !== "standard" &&

--- a/module/scripts/dark-sheet.js
+++ b/module/scripts/dark-sheet.js
@@ -32,6 +32,9 @@ Hooks.on("renderActorSheet", () => {
             element.classList.add("dark-theme");
             element.classList.add(mode);
         }
+    }
+})
+
 Hooks.on("renderActorSheet", (app, html) => {
     if (
         game.settings.get('pathfinder-ui', 'darkSheetToggle') !== 'standard' &&


### PR DESCRIPTION
## Summary
- Close `renderActorSheet`, `renderNPCSheetPF2e`, and `renderJournalSheetPF2e` loops before defining additional Hooks
- Define second `Hooks.on` handlers as standalone statements

## Testing
- `npm test` *(fails: enoent Could not read package.json)*
- `node --check module/scripts/dark-sheet.js`
- `node --check module/scripts/dark-party-sheet.js`
- `node --check module/scripts/dark-npc-sheet.js`
- `node --check module/scripts/dark-custom.js`


------
https://chatgpt.com/codex/tasks/task_e_68a859044844832794b3b5b054219127