### PR TITLE
Fix UI bar alignment by removing oversized widths

### DIFF
--- a/module/css/pathfinderui.css
+++ b/module/css/pathfinderui.css
@@ -957,9 +957,9 @@ hr {
     position: absolute;
     z-index: -1;
     content: " ";
-    width: 146%;
-    bottom: -10px;
-    left: -23%;
+    width: 100%;
+    bottom: 0;
+    left: 0;
     height: 85px;
     background-image: url(../ui/frames/action_bar.webp);
     background-size: 100% 85px;
@@ -1234,7 +1234,7 @@ button#roll-hd:hover::before {
 
 /* NAVIGATION */
 #ui-top {
-    width: calc(103%);
+    width: 100%;
 }
 
 #navigation #nav-toggle {


### PR DESCRIPTION
## Summary
- prevent top UI bar from extending past viewport
- keep action bar background within bounds to avoid pushing elements

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a868249c948327857b400257c49586