### PR TITLE
Fix misaligned UI layout elements

### DIFF
--- a/module/css/pathfinderui.css
+++ b/module/css/pathfinderui.css
@@ -244,10 +244,10 @@ body.compact-mode #logo {
     position: absolute;
     z-index: -1;
     content: " ";
-    height: calc(100% + 10px);
+    height: 100%;
     width: 100%;
     left: 0;
-    top: 5px;
+    top: 0;
     background: url(../ui/frames/chat.webp);
     background-size: 100% 100%;
 }
@@ -545,14 +545,14 @@ body.compact-mode #logo {
 }
 
 #chat-controls::before {
-    position: relative;
+    position: absolute;
     content: ' ';
     background: url(../ui/frames/brown_line.webp);
     background-size: 300px 7px;
     left: -3px;
     width: var(--sidebar-width);
     height: 7px;
-    bottom: 8px;
+    top: -8px;
 }
 
 #chat-log .message {
@@ -924,7 +924,7 @@ hr {
     display: none;
 }
 #ui-bottom > div {
-    justify-content: center;
+    justify-content: flex-start;
 }
 
 #hotbar {


### PR DESCRIPTION
## Summary
- Avoid centering the bottom UI bar
- Keep chat controls decoration from pushing the input field
- Remove unwanted top gap in sidebar background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86a6fbf448327913d5f3307f872a6