### PR TITLE
Disable custom banner rendering

### DIFF
--- a/module/scripts/rpg-ui.js
+++ b/module/scripts/rpg-ui.js
@@ -176,8 +176,8 @@ Hooks.on('init', () => {
 	});
 
 	if (!game.settings.get('pathfinder-ui', 'compactModeToggle')) {
-		if (!game.settings.get('pathfinder-ui', 'standardLogoToggle')) {
-			addClassByQuerySelector("hide", "img#logo")
+                if (!game.settings.get('pathfinder-ui', 'standardLogoToggle')) {
+                        // addClassByQuerySelector("hide", "img#logo");
 
                         let newLogo = document.createElement('div');
                         let uiLeft = document.getElementById('ui-left');
@@ -186,7 +186,7 @@ Hooks.on('init', () => {
                         } else {
                                 newLogo.classList.add("new-logo");
                                 newLogo.innerText = "Pathfinder \n2e";
-                                uiLeft.prepend(newLogo);
+                                // uiLeft.prepend(newLogo);
                         }
                 }
         }


### PR DESCRIPTION
## Summary
- remove calls hiding the default logo and prepending custom banner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ddb9fec8327888110f9038b3a54