### PR TITLE
Ensure hotbar visible with PF2e HUD

### DIFF
--- a/module/css/pf2e-hud.css
+++ b/module/css/pf2e-hud.css
@@ -152,6 +152,11 @@
   border: 2px dotted var(--color-warm-5);
   box-shadow: var(--box-shadow);
 }
+#pf2e-hud-persistent #hotbar {
+  display: flex !important;
+  visibility: visible;
+  opacity: 1;
+}
 #pf2e-hud-persistent #hotbar #action-bar {
   gap: 5px;
 }


### PR DESCRIPTION
## Summary
- keep Foundry hotbar visible when PF2e HUD is active by forcing display, visibility and opacity

## Testing
- `npm test` (fails: package.json missing)

------
https://chatgpt.com/codex/tasks/task_e_68acaa1a2a34832781651674c18c0ec5