### PR TITLE
fix: overlay sidebar with fixed positioning

### DIFF
--- a/module/css/pathfinderui.css
+++ b/module/css/pathfinderui.css
@@ -216,7 +216,9 @@ body.compact-mode #logo {
     justify-content: flex-start;
     width: var(--sidebar-width);
     height: calc(100% - 10px);
-    position: relative;
+    position: fixed;
+    top: 0;
+    right: 0;
     overflow: visible;
     margin: -10px 0 0 0px;
     padding: 0;
@@ -235,6 +237,8 @@ body.compact-mode #logo {
 }
 
 #sidebar.app.collapsed::before {
+    position: absolute;
+    z-index: -1;
     width: 40px !important;
     left: -4px !important;
     height: 110% !important;


### PR DESCRIPTION
## Summary
- Set `#sidebar` to `position: fixed` to overlay and keep chat bar and settings panel static
- Explicitly position sidebar background pseudo-element behind content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acab865e248327a1512a5aa4ad460e